### PR TITLE
user: new 'dif-policy-list' and 'dif-policy-param-list' commands for rlite-ctl

### DIFF
--- a/include/rlite/uipcps-msg.h
+++ b/include/rlite/uipcps-msg.h
@@ -32,20 +32,24 @@
 /* Message types. They **must** be listed alternating requests with
  * the corresponding responses. */
 enum {
-    RLITE_U_IPCP_REGISTER = 1,      /* 1 */
-    RLITE_U_IPCP_ENROLL,            /* 2 */
-    RLITE_U_BASE_RESP,              /* 3 */
-    RLITE_U_IPCP_RIB_SHOW_REQ,      /* 4 */
-    RLITE_U_IPCP_RIB_SHOW_RESP,     /* 5 */
-    RLITE_U_IPCP_LOWER_FLOW_ALLOC,  /* 6 */
-    RLITE_U_MEMTRACK_DUMP,          /* 7 */
-    RLITE_U_IPCP_POLICY_MOD,        /* 8 */
-    RLITE_U_IPCP_ENROLLER_ENABLE,   /* 9 */
-    RLITE_U_IPCP_ROUTING_SHOW_REQ,  /* 10 */
-    RLITE_U_IPCP_ROUTING_SHOW_RESP, /* 11 */
-    RLITE_U_IPCP_POLICY_PARAM_MOD,  /* 12 */
-    RLITE_U_IPCP_CONFIG,            /* 13 */
-    RLITE_U_PROBE,                  /* 14 */
+    RLITE_U_IPCP_REGISTER = 1,            /* 1 */
+    RLITE_U_IPCP_ENROLL,                  /* 2 */
+    RLITE_U_BASE_RESP,                    /* 3 */
+    RLITE_U_IPCP_RIB_SHOW_REQ,            /* 4 */
+    RLITE_U_IPCP_RIB_SHOW_RESP,           /* 5 */
+    RLITE_U_IPCP_LOWER_FLOW_ALLOC,        /* 6 */
+    RLITE_U_MEMTRACK_DUMP,                /* 7 */
+    RLITE_U_IPCP_POLICY_MOD,              /* 8 */
+    RLITE_U_IPCP_ENROLLER_ENABLE,         /* 9 */
+    RLITE_U_IPCP_ROUTING_SHOW_REQ,        /* 10 */
+    RLITE_U_IPCP_ROUTING_SHOW_RESP,       /* 11 */
+    RLITE_U_IPCP_POLICY_PARAM_MOD,        /* 12 */
+    RLITE_U_IPCP_CONFIG,                  /* 13 */
+    RLITE_U_PROBE,                        /* 14 */
+    RLITE_U_IPCP_POLICY_LIST_REQ,         /* 15 */
+    RLITE_U_IPCP_POLICY_LIST_RESP,        /* 16 */
+    RLITE_U_IPCP_POLICY_PARAM_LIST_REQ,   /* 17 */
+    RLITE_U_IPCP_POLICY_PARAM_LIST_RESP,  /* 18 */
 
     RLITE_U_MSG_MAX,
 };
@@ -107,6 +111,18 @@ struct rl_cmsg_ipcp_policy_mod {
     char *policy_name;
 } __attribute__((packed));
 
+/* rlite-ctl --> uipcps message to list DIF policies */
+struct rl_cmsg_ipcp_policy_list_req {
+    rl_msg_t msg_type;
+    uint32_t event_id;
+
+    char *ipcp_name;
+    char *comp_name;
+} __attribute__((packed));
+
+/* rlite-ctl <-- uipcps message to list DIF policies */
+#define rl_cmsg_ipcp_policy_list_resp rl_cmsg_ipcp_rib_show_resp
+
 /* rlite-ctl --> uipcps message to change a DIF policy parameter */
 struct rl_cmsg_ipcp_policy_param_mod {
     rl_msg_t msg_type;
@@ -117,6 +133,19 @@ struct rl_cmsg_ipcp_policy_param_mod {
     char *param_name;
     char *param_value;
 } __attribute__((packed));
+
+/* rlite-ctl --> uipcps message to list DIF policies */
+struct rl_cmsg_ipcp_policy_param_list_req {
+    rl_msg_t msg_type;
+    uint32_t event_id;
+
+    char *ipcp_name;
+    char *comp_name;
+    char *param_name;
+} __attribute__((packed));
+
+/* rlite-ctl <-- uipcps message to list DIF policy parameters */
+#define rl_cmsg_ipcp_policy_param_list_resp rl_cmsg_ipcp_rib_show_resp
 
 /* rlite-ctl --> uipcp message to let the IPCP accept
  * enrollment requests even if it is not enrolled in

--- a/user/libs/uipcps-numtables.c
+++ b/user/libs/uipcps-numtables.c
@@ -96,6 +96,30 @@ struct rl_msg_layout rl_uipcps_numtables[] = {
         {
             .copylen = sizeof(struct rl_msg_base),
         },
+    [RLITE_U_IPCP_POLICY_LIST_REQ] =
+        {
+            .copylen = sizeof(struct rl_cmsg_ipcp_policy_list_req) -
+                       2 * sizeof(char *),
+            .strings = 2,
+        },
+    [RLITE_U_IPCP_POLICY_LIST_RESP] =
+        {
+            .copylen = sizeof(struct rl_cmsg_ipcp_policy_list_resp) -
+                       1 * sizeof(struct rl_buf_field),
+            .buffers = 1,
+        },
+    [RLITE_U_IPCP_POLICY_PARAM_LIST_REQ] =
+        {
+            .copylen = sizeof(struct rl_cmsg_ipcp_policy_param_list_req) -
+                       3 * sizeof(char *),
+            .strings = 3,
+        },
+    [RLITE_U_IPCP_POLICY_PARAM_LIST_RESP] =
+        {
+            .copylen = sizeof(struct rl_cmsg_ipcp_policy_param_list_resp) -
+                       1 * sizeof(struct rl_buf_field),
+            .buffers = 1,
+        },
     [RLITE_U_MEMTRACK_DUMP] =
         {
             .copylen = sizeof(struct rl_msg_base),

--- a/user/tools/rlite-ctl.c
+++ b/user/tools/rlite-ctl.c
@@ -846,6 +846,99 @@ ipcp_rib_show(int argc, char **argv, struct cmd_descriptor *cd)
     return request_response(RLITE_MB(&req), ipcp_rib_show_handler);
 }
 
+static int
+ipcp_policy_list(int argc, char **argv, struct cmd_descriptor *cd)
+{
+    struct rl_cmsg_ipcp_policy_list_req req;
+    const char *name;
+    const char *comp_name = NULL;
+    struct ipcp_attrs *attrs;
+
+    assert(argc >= 1);
+    name = argv[0];
+
+    comp_name = NULL;
+    if( argc >= 2) {
+        comp_name = argv[1];
+    }
+
+    if (strcmp(cd->name, "dif-policy-list") == 0) {
+        attrs = ipcp_by_dif(name);
+        if (!attrs) {
+            PE("Could not find any IPCP in DIF %s\n", name);
+            return -1;
+        }
+        req.ipcp_name = strdup(attrs->name);
+    } else {
+        req.ipcp_name = strdup(name);
+        attrs         = lookup_ipcp_by_name(req.ipcp_name);
+        if (!attrs) {
+            PE("Could not find IPC process %s\n", name);
+            return -1;
+        }
+    }
+
+    req.msg_type    = RLITE_U_IPCP_POLICY_LIST_REQ;
+    req.event_id    = 0;
+    req.comp_name   = NULL;
+    if (comp_name) {
+        req.comp_name = strdup(comp_name);
+    }
+
+    return request_response(RLITE_MB(&req), ipcp_rib_show_handler);
+}
+
+static int
+ipcp_policy_param_list(int argc, char **argv, struct cmd_descriptor *cd)
+{
+    struct rl_cmsg_ipcp_policy_param_list_req req;
+    const char *name;
+    const char *comp_name;
+    const char *param_name;
+    struct ipcp_attrs *attrs;
+
+    assert(argc >= 1);
+    name = argv[0];
+
+    comp_name = NULL;
+    if( argc >= 2) {
+        comp_name = argv[1];
+    }
+
+    param_name = NULL;
+    if( argc >= 3) {
+        param_name = argv[2];
+    }
+
+    if (strcmp(cd->name, "dif-policy-param-list") == 0) {
+        attrs = ipcp_by_dif(name);
+        if (!attrs) {
+            PE("Could not find any IPCP in DIF %s\n", name);
+            return -1;
+        }
+        req.ipcp_name = strdup(attrs->name);
+    } else {
+        req.ipcp_name = strdup(name);
+        attrs         = lookup_ipcp_by_name(req.ipcp_name);
+        if (!attrs) {
+            PE("Could not find IPC process %s\n", name);
+            return -1;
+        }
+    }
+
+    req.msg_type    = RLITE_U_IPCP_POLICY_PARAM_LIST_REQ;
+    req.event_id    = 0;
+    req.comp_name   = NULL;
+    if (comp_name) {
+        req.comp_name = strdup(comp_name);
+    }
+    if (param_name) {
+        req.param_name = strdup(param_name);
+    }
+
+    return request_response(RLITE_MB(&req), ipcp_rib_show_handler);
+}
+
 /* Build the list of IPCPs running in the system, ordered by id. */
 static int
 ipcps_load()
@@ -1020,10 +1113,22 @@ static struct cmd_descriptor cmd_descriptors[] = {
         .func     = ipcp_policy_mod,
     },
     {
+        .name     = "dif-policy-list",
+        .usage    = "DIF_NAME [COMPONENT_NAME]",
+        .num_args = 1,
+        .func     = ipcp_policy_list,
+    },
+    {
         .name     = "dif-policy-param-mod",
         .usage    = "DIF_NAME COMPONENT_NAME PARAM_NAME PARAM_VALUE",
         .num_args = 4,
         .func     = ipcp_policy_param_mod,
+    },
+    {
+        .name     = "dif-policy-param-list",
+        .usage    = "DIF_NAME [COMPONENT_NAME] [PARAM_NAME]",
+        .num_args = 1,
+        .func     = ipcp_policy_param_list,
     },
     {
         .name     = "ipcp-enroller-enable",

--- a/user/uipcps/uipcp-container.h
+++ b/user/uipcps/uipcp-container.h
@@ -142,9 +142,19 @@ struct uipcp_ops {
     int (*policy_mod)(struct uipcp *uipcp,
                       const struct rl_cmsg_ipcp_policy_mod *req);
 
+    /* User wants to list policies of this uipcp. */
+    int (*policy_list)(struct uipcp *uipcp,
+                       const struct rl_cmsg_ipcp_policy_list_req *req,
+                       char **resp_msg);
+
     /* User wants to change a policy param of this uipcp. */
     int (*policy_param_mod)(struct uipcp *uipcp,
                             const struct rl_cmsg_ipcp_policy_param_mod *req);
+
+    /* User wants to list policy parameters of this uipcp. */
+    int (*policy_param_list)(struct uipcp *uipcp,
+                             const struct rl_cmsg_ipcp_policy_param_list_req *req,
+                             char **resp_msg);
 
     /* User wnats to change a configuration parameter of this uipcp.
      * This request may be forwarded to kernel-space. */

--- a/user/uipcps/uipcp-normal.hpp
+++ b/user/uipcps/uipcp-normal.hpp
@@ -103,6 +103,8 @@ struct PolicyParam {
     PolicyParam(bool param_value);
     PolicyParam(int param_value);
 
+    friend std::ostream& operator<<(std::ostream &os, const PolicyParam &param);
+
     int set_value(const std::string &param_value);
     bool get_bool_value() const;
     int get_int_value() const;


### PR DESCRIPTION
I've tried to make the command output clear and user-friendly, here's some examples:
```
# rlite-ctl dif-policy-list n3.DIF
resource-allocator
        default
enrollment
        default
address-allocator
        [distributed] manual
routing
        link-state-lfa [link-state]
# rlite-ctl dif-policy-list n3.DIF routing
link-state-lfa [link-state]
# rlite-ctl dif-policy-param-list n3.DIF
rib-daemon
        refresh-intval = 30
address-allocator
enrollment
        keepalive-thresh = 3
        keepalive = 10
        timeout = 7000
flow-allocator
        force-flow-control = false
routing
        age-max = 120
        age-incr-intval = 2
resource-allocator
        broadcast-enroller = true
        reliable-n-flows = false
        reliable-flows = false
# rlite-ctl dif-policy-param-list n3.DIF routing
routing.age-max = 120
routing.age-incr-intval = 2
# rlite-ctl dif-policy-param-list n3.DIF routing age-max
routing.age-max = 120
```